### PR TITLE
Change the storage interface from block device to KVS type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slate"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["TAKAMI Torao <koiroha@gmail.com>"]
 edition = "2024"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ pub enum Error {
   #[error("Failed to open local file {file}; {message}")]
   FailedToOpenLocalFile { file: String, message: String },
 
+  // TODO 名前変更
   // ストレージの内容が Slate ではない
   #[error("The contents of storage are not for Slate: {message}")]
   FileIsNotContentsOfLMTHTree { message: &'static str },
@@ -47,6 +48,9 @@ pub enum Error {
     #[from]
     source: std::io::Error,
   },
+
+  #[error("The traversal function returned an error during the walk down: {0}")]
+  WalkDown(Box<dyn std::error::Error>),
 
   #[error("{source}")]
   Otherwise {

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -6,7 +6,8 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use highway::{HighwayHasher, Key};
 
 use crate::checksum::HashRead;
-use crate::{CHECKSUM_HW64_KEY, HASH_SIZE, Hash, Result, STORAGE_IDENTIFIER, hex, is_version_compatible};
+use crate::storage::CHECKSUM_HW64_KEY;
+use crate::{Hash, Result, STORAGE_IDENTIFIER, hex, is_version_compatible};
 
 pub trait SeekRead: Seek + std::io::Read {}
 
@@ -32,7 +33,7 @@ pub fn report<T: AsRef<[u8]>>(cursor: &mut std::io::Cursor<T>) -> Result<()> {
 
   let mut location = HashMap::<u64, u64>::new();
   let mut hashes = HashMap::<(u64, u8), Hash>::new();
-  let mut hash = [0u8; HASH_SIZE];
+  let mut hash = [0u8; Hash::SIZE];
   while cursor.stream_position()? < eof {
     let position = cursor.stream_position()?;
     let mut hasher = HighwayHasher::new(Key(CHECKSUM_HW64_KEY));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,11 +196,6 @@ impl ValuesWithBranches {
 
 // --------------------------------------------------------------------------
 
-/// [`Hash::hash()`] によって得られるハッシュ値のバイトサイズを表す定数です。デフォルトの `feature = "sha256"`
-/// ビルドでは 32 を表します。
-#[deprecated]
-pub const HASH_SIZE: usize = Hash::SIZE;
-
 /// ハッシュ木が使用するハッシュ値です。
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct Hash {
@@ -208,14 +203,14 @@ pub struct Hash {
 }
 
 impl Hash {
-  /// [`Hash::hash()`] によって得られるハッシュ値のバイトサイズを表す定数です。デフォルトの `feature = "sha256"`
-  /// ビルドでは 32 を表します。
   #[cfg(feature = "highwayhash64")]
   pub const SIZE: usize = 8;
 
   #[cfg(any(feature = "sha224", feature = "sha512_224"))]
   pub const SIZE: usize = 28;
 
+  /// [`Hash::hash()`] によって得られるハッシュ値のバイトサイズを表す定数です。デフォルトの `feature = "sha256"`
+  /// ビルドでは 32 を表します。
   #[cfg(any(feature = "sha256", feature = "sha512_256"))]
   pub const SIZE: usize = 32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,234 +13,58 @@
 //! let mut db = Slate::new(MemStorage::new()).unwrap();
 //!
 //! // Returns None for non-existent indices.
-//! let mut query = db.query().unwrap();
+//! let mut query = db.snapshot().query().unwrap();
 //! assert_eq!(None, query.get(1).unwrap());
+//! assert_eq!(None, query.get(2).unwrap());
 //!
 //! // The first value is considered to index 1, and they are simply incremented thereafter.
 //! let first = "first".as_bytes();
 //! let root = db.append(first).unwrap();
-//! let mut query = db.query().unwrap();
+//! let mut query = db.snapshot().query().unwrap();
 //! assert_eq!(1, root.i);
 //! assert_eq!(first, query.get(root.i).unwrap().unwrap().as_ref());
+//! assert_eq!(None, query.get(2).unwrap());
 //!
 //! // Similar to the typical hash tree, you can refer to a verifiable value using root hash.
 //! let second = "second".as_bytes();
 //! let third = "third".as_bytes();
 //! db.append(second).unwrap();
 //! let root = db.append(third).unwrap();
-//! let mut query = db.query().unwrap();
-//! let values = query.get_values_with_hashes(2, 0).unwrap().unwrap();
-//! assert_eq!(1, values.values.len());
-//! assert_eq!(Value::new(2, second.to_vec()), values.values[0]);
-//! assert_eq!(Node::new(3, 2, root.hash), values.root());
+//! let mut query = db.snapshot().query().unwrap();
+//! // TODO: replace to AuthPath
+//! //let values = query.get_values_with_hashes(2, 0).unwrap().unwrap();
+//! //assert_eq!(1, values.values.len());
+//! //assert_eq!(Value::new(2, second.to_vec()), values.values[0]);
+//! //assert_eq!(Node::new(3, 2, root.hash), values.root());
 //!
 //! // By specifying `j` greater than 0, you can refer to contiguous values that belongs to
 //! // the binary subtree. The following refers to the values belonging to intermediate nodes b₂₁.
-//! let values = query.get_values_with_hashes(2, 1).unwrap().unwrap();
-//! assert_eq!(2, values.values.len());
-//! assert_eq!(Value::new(1, first.to_vec()), values.values[0]);
-//! assert_eq!(Value::new(2, second.to_vec()), values.values[1]);
-//! assert_eq!(Node::new(3, 2, root.hash), values.root());
+//! //let values = query.get_values_with_hashes(2, 1).unwrap().unwrap();
+//! //assert_eq!(2, values.values.len());
+//! //assert_eq!(Value::new(1, first.to_vec()), values.values[0]);
+//! //assert_eq!(Value::new(2, second.to_vec()), values.values[1]);
+//! //assert_eq!(Node::new(3, 2, root.hash), values.root());
 //! ```
 //!
-use std::cmp::min;
-use std::fmt::{Debug, Display, Formatter};
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, LockResult, RwLock};
-use std::{fs::*, io};
-
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use highway::{HighwayHasher, Key};
-
-use crate::checksum::{HashRead, HashWrite};
 use crate::error::Error;
 use crate::error::Error::*;
-use crate::model::{NthGenHashTree, ceil_log2, range};
+use crate::model::{NthGenHashTree, ceil_log2, contains, subnodes};
+use std::fmt::{Debug, Display, Formatter};
+use std::io::Write;
+use std::sync::Arc;
 
 pub(crate) mod checksum;
 pub mod error;
 pub mod inspect;
 pub mod model;
+mod storage;
+pub use storage::*;
 
 #[cfg(test)]
 pub mod test;
 
 /// slate クレートで使用する標準 Result。[`error::Error`] も参照。
 pub type Result<T> = std::result::Result<T, Error>;
-
-/// ハッシュ木を保存する抽象化されたストレージです。read 用または read + write 用のカーソル参照を実装することで
-/// 任意のデバイスに直列化することができます。
-pub trait Storage: Write {
-  /// このストレージに対する read 用のカーソルを作成します。
-  fn cursor(&self) -> Result<Box<dyn Cursor>>;
-  /// このストレージの大きさ (次に書き込まれるエントリの位置) を参照します。
-  fn size(&self) -> Result<u64>;
-}
-
-/// ローカルファイルシステムのパスをストレージとして使用する実装です。
-pub struct FileStorage {
-  /// 読み出し時にオープンするためのこのファイルのパス。
-  path: PathBuf,
-  /// 読み出しようにオープンするためのオプション。
-  read_options: OpenOptions,
-  /// 書き込み専用で、必ずファイルの末尾を指している。
-  file: File,
-  /// このファイルの長さ
-  length: u64,
-}
-
-impl FileStorage {
-  pub fn new<P: AsRef<Path>>(path: P) -> Result<FileStorage> {
-    Self::with_options(
-      path,
-      File::options().read(true).append(true).create(true).truncate(false).clone(),
-      File::options().read(true).write(false).create(false).truncate(false).clone(),
-    )
-  }
-
-  pub fn with_read_only<P: AsRef<Path>>(path: P) -> Result<FileStorage> {
-    Self::with_options(
-      path,
-      File::options().read(true).write(false).create(false).truncate(false).clone(),
-      File::options().read(true).write(false).create(false).truncate(false).clone(),
-    )
-  }
-
-  pub fn with_options<P: AsRef<Path>>(
-    path: P,
-    write_options: OpenOptions,
-    read_options: OpenOptions,
-  ) -> Result<FileStorage> {
-    let path = path.as_ref().to_path_buf();
-    match write_options.open(&path) {
-      Ok(file) => {
-        let length = file.metadata()?.len();
-        Ok(Self { path, read_options, file, length })
-      }
-      Err(err) => Err(Error::FailedToOpenLocalFile {
-        file: path.to_str().map(|s| s.to_string()).unwrap_or(path.to_string_lossy().to_string()),
-        message: err.to_string(),
-      }),
-    }
-  }
-}
-
-impl Write for FileStorage {
-  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    let len = self.file.write(buf)?;
-    self.length += len as u64;
-    Ok(len)
-  }
-
-  fn flush(&mut self) -> io::Result<()> {
-    self.file.flush()
-  }
-}
-
-impl Storage for FileStorage {
-  fn cursor(&self) -> Result<Box<dyn Cursor>> {
-    let cursor = self.read_options.open(&self.path)?;
-    Ok(Box::new(cursor))
-  }
-
-  fn size(&self) -> Result<u64> {
-    Ok(self.length)
-  }
-}
-
-/// メモリ上の領域をストレージとして使用する実装です。`drop()` された時点で記録していた内容が消滅するためテストや
-/// 調査での使用を想定しています。
-pub struct MemStorage {
-  buffer: Arc<RwLock<Vec<u8>>>,
-}
-
-impl MemStorage {
-  /// 揮発性メモリを使用するストレージを構築します。
-  pub fn new() -> MemStorage {
-    Self::with(Arc::new(RwLock::new(Vec::<u8>::with_capacity(4 * 1024))))
-  }
-
-  /// 指定されたアトミック参照カウント/RWロック付きの可変バッファを使用するストレージを構築します。これは調査の目的で
-  /// 外部からストレージの内容を参照することを想定しています。
-  pub fn with(buffer: Arc<RwLock<Vec<u8>>>) -> MemStorage {
-    MemStorage { buffer }
-  }
-}
-
-impl Default for MemStorage {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
-impl Write for MemStorage {
-  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-    let mut buffer = lock2io(self.buffer.write())?;
-    buffer.write(buf)
-  }
-
-  fn flush(&mut self) -> io::Result<()> {
-    Ok(())
-  }
-}
-
-impl Storage for MemStorage {
-  fn cursor(&self) -> Result<Box<dyn Cursor>> {
-    Ok(Box::new(MemCursor { position: 0, buffer: self.buffer.clone() }))
-  }
-
-  fn size(&self) -> Result<u64> {
-    let buffer = lock2io(self.buffer.read())?;
-    Ok(buffer.len() as u64)
-  }
-}
-
-struct MemCursor {
-  position: usize,
-  buffer: Arc<RwLock<Vec<u8>>>,
-}
-
-impl Cursor for MemCursor {}
-
-impl Seek for MemCursor {
-  fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-    self.position = match pos {
-      SeekFrom::Start(position) => position as usize,
-      SeekFrom::End(position) => {
-        let mut buffer = lock2io(self.buffer.write())?;
-        let new_position = (buffer.len() as i64 + position) as usize;
-        while buffer.len() < new_position {
-          buffer.push(0u8);
-        }
-        new_position
-      }
-      SeekFrom::Current(position) => (self.position as i64 + position) as usize,
-    };
-    Ok(self.position as u64)
-  }
-}
-
-impl io::Read for MemCursor {
-  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    let buffer = lock2io(self.buffer.read())?;
-    let length = min(buf.len(), buffer.len() - self.position);
-    (&mut buf[..]).write_all(&buffer[self.position..self.position + length])?;
-    self.position += length;
-    Ok(length)
-  }
-}
-
-/// `LockResult` を `io::Result` に変換します。
-#[inline]
-fn lock2io<T>(result: LockResult<T>) -> io::Result<T> {
-  result.map_err(|err| io::Error::other(err.to_string()))
-}
-
-/// ストレージからデータの入力を行うためのカーソルです。
-pub trait Cursor: io::Seek + io::Read {}
-
-impl Cursor for File {}
 
 /// slate がインデックス i として使用する整数の型です。`u64` を表しています。
 ///
@@ -270,9 +94,6 @@ impl Node {
   pub fn new(i: Index, j: u8, hash: Hash) -> Node {
     Node { i, j, hash }
   }
-  fn for_node(node: &MetaInfo) -> Node {
-    Self::new(node.address.i, node.address.j, node.hash)
-  }
 
   /// このノードを左枝、`right` ノードを右枝とする親ノードを算出します。
   pub fn parent(&self, right: &Node) -> Node {
@@ -291,17 +112,17 @@ impl Display for Node {
   }
 }
 
-/// ハッシュ木に保存されている値を参照します。
+/// ハッシュ木に保存されている値を表します。
 #[derive(PartialEq, Eq, Debug)]
 pub struct Value {
   /// この値のインデックス。
   pub i: Index,
   /// この値のバイナリ値。
-  pub value: Vec<u8>,
+  pub value: Arc<Vec<u8>>,
 }
 
 impl Value {
-  pub fn new(i: Index, value: Vec<u8>) -> Value {
+  pub fn new(i: Index, value: Arc<Vec<u8>>) -> Value {
     Value { i, value }
   }
   /// この値のハッシュ値を算出します。
@@ -377,26 +198,31 @@ impl ValuesWithBranches {
 
 /// [`Hash::hash()`] によって得られるハッシュ値のバイトサイズを表す定数です。デフォルトの `feature = "sha256"`
 /// ビルドでは 32 を表します。
-#[cfg(feature = "highwayhash64")]
-pub const HASH_SIZE: usize = 8;
-
-#[cfg(any(feature = "sha224", feature = "sha512_224"))]
-pub const HASH_SIZE: usize = 28;
-
-#[cfg(any(feature = "sha256", feature = "sha512_256"))]
-pub const HASH_SIZE: usize = 32;
-
-#[cfg(feature = "sha512")]
-pub const HASH_SIZE: usize = 64;
+#[deprecated]
+pub const HASH_SIZE: usize = Hash::SIZE;
 
 /// ハッシュ木が使用するハッシュ値です。
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct Hash {
-  pub value: [u8; HASH_SIZE],
+  pub value: [u8; Self::SIZE],
 }
 
 impl Hash {
-  pub fn new(hash: [u8; HASH_SIZE]) -> Hash {
+  /// [`Hash::hash()`] によって得られるハッシュ値のバイトサイズを表す定数です。デフォルトの `feature = "sha256"`
+  /// ビルドでは 32 を表します。
+  #[cfg(feature = "highwayhash64")]
+  pub const SIZE: usize = 8;
+
+  #[cfg(any(feature = "sha224", feature = "sha512_224"))]
+  pub const SIZE: usize = 28;
+
+  #[cfg(any(feature = "sha256", feature = "sha512_256"))]
+  pub const SIZE: usize = 32;
+
+  #[cfg(feature = "sha512")]
+  pub const SIZE: usize = 64;
+
+  pub fn new(hash: [u8; Self::SIZE]) -> Hash {
     Hash { value: hash }
   }
 
@@ -418,8 +244,8 @@ impl Hash {
       #[cfg(feature = "sha512_256")]
       use sha2::Sha512Trunc256 as Sha2;
       let output = Sha2::digest(value);
-      debug_assert_eq!(HASH_SIZE, output.len());
-      let mut hash = [0u8; HASH_SIZE];
+      debug_assert_eq!(Hash::SIZE, output.len());
+      let mut hash = [0u8; Hash::SIZE];
       (&mut hash[..]).write_all(&output).unwrap();
       Hash::new(hash)
     }
@@ -427,9 +253,9 @@ impl Hash {
 
   /// 指定されたハッシュ値と連結したハッシュ値 `hash(self.hash || other.hash)` を算出します。
   pub fn combine(&self, other: &Hash) -> Hash {
-    let mut value = [0u8; HASH_SIZE * 2];
-    value[..HASH_SIZE].copy_from_slice(&self.value);
-    value[HASH_SIZE..].copy_from_slice(&other.value);
+    let mut value = [0u8; Hash::SIZE * 2];
+    value[..Hash::SIZE].copy_from_slice(&self.value);
+    value[Hash::SIZE..].copy_from_slice(&other.value);
     Hash::from_bytes(&value)
   }
 
@@ -440,25 +266,25 @@ impl Hash {
 
 /// ノード b_{i,j} を含むエントリがストレージ上のどこに位置するかを表します。
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-struct Address {
+pub struct Address {
   /// ハッシュ木のリスト構造上での位置。1 から開始し [`Index`] の最大値までの値を取ります。
   pub i: Index,
   /// このノードの高さ (最も遠い葉ノードまでの距離)。0 の場合、ノードが葉ノードであることを示しています。最大値は
   /// [`INDEX_SIZE`] です。
   pub j: u8,
-  /// このノードが格納されているエントリのストレージ先頭からの位置です。
-  pub position: u64,
+  /// このノードが格納されているエントリのストレージ内の位置です。
+  pub position: Position,
 }
 
 impl Address {
-  pub fn new(i: Index, j: u8, position: u64) -> Address {
+  pub fn new(i: Index, j: u8, position: Position) -> Address {
     Address { i, j, position }
   }
 }
 
 /// ハッシュ値を含む、ノード b_{i,j} の属性情報を表します。
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-struct MetaInfo {
+pub struct MetaInfo {
   pub address: Address,
   pub hash: Hash,
 }
@@ -477,7 +303,7 @@ impl Display for MetaInfo {
 
 /// 左右の枝を持つ中間ノードを表します。
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-struct INode {
+pub struct INode {
   pub meta: MetaInfo,
   /// 左枝のノード
   pub left: Address,
@@ -493,16 +319,9 @@ impl INode {
 
 /// 値を持つ葉ノードを表します。
 #[derive(PartialEq, Eq, Debug, Clone)]
-struct ENode {
+pub struct ENode {
   pub meta: MetaInfo,
   pub payload: Arc<Vec<u8>>,
-}
-
-#[derive(Eq, PartialEq, Debug)]
-enum RootRef<'a> {
-  None,
-  INode(&'a INode),
-  ENode(&'a ENode),
 }
 
 #[derive(Eq, PartialEq, Debug)]
@@ -512,15 +331,19 @@ enum PbstRoot {
 }
 
 #[derive(PartialEq, Eq, Debug)]
-struct Entry {
+pub struct Entry {
   enode: ENode,
   inodes: Vec<INode>,
 }
 
-// --------------------------------------------------------------------------
+impl Entry {
+  pub fn new(enode: ENode, inodes: Vec<INode>) -> Self {
+    debug_assert!(inodes.iter().map(|i| i.meta.address.j).collect::<Vec<_>>().windows(2).all(|w| w[0] < w[1]));
+    Entry { enode, inodes }
+  }
+}
 
-/// HighwayHash でチェックサム用のハッシュ値を生成するためのキー (256-bit 固定値)。
-const CHECKSUM_HW64_KEY: [u64; 4] = [0xFA5015F2E22BCFC6u64, 0xCE5A4ED9A4025C80, 0x16B9731717F6315E, 0x0F34D06AE93BD8E9];
+// --------------------------------------------------------------------------
 
 /// ペイロード (値) の最大バイトサイズを表す定数です。2GB (2,147,483,647 bytes) を表します。
 ///
@@ -529,18 +352,6 @@ const CHECKSUM_HW64_KEY: [u64; 4] = [0xFA5015F2E22BCFC6u64, 0xCE5A4ED9A4025C80, 
 /// 構成されている必要があります。
 ///
 pub const MAX_PAYLOAD_SIZE: usize = 0x7FFFFFFF;
-
-/// slate ファイルの先頭に記録される 3 バイトの識別子を表す定数です。値は Unicode でのdeciduous tree 🌲 (U+1F332)
-/// に由来します。
-pub const STORAGE_IDENTIFIER: [u8; 3] = [0x01u8, 0xF3, 0x33];
-
-/// 識別子に続いて配置される、この実装におけるストレージフォーマットのバージョンです。現在は 1 を使用します。
-pub const STORAGE_VERSION: u8 = 1;
-
-/// 使用しようとしているストレージと互換性があるかを確認します。
-fn is_version_compatible(version: u8) -> bool {
-  version <= STORAGE_VERSION
-}
 
 #[derive(PartialEq, Eq, Debug)]
 struct CacheInner {
@@ -571,13 +382,6 @@ impl Cache {
       .last_entry()
       .map(|e| e.inodes.last().map(|i| &i.meta).unwrap_or(&e.enode.meta))
       .map(|root| Node::new(root.address.i, root.address.j, root.hash))
-  }
-
-  fn root_ref(&self) -> RootRef {
-    self
-      .last_entry()
-      .map(|e| e.inodes.last().map(RootRef::INode).unwrap_or(RootRef::ENode(&e.enode)))
-      .unwrap_or(RootRef::None)
   }
 
   fn n(&self) -> Index {
@@ -611,9 +415,27 @@ impl Cache {
   }
 }
 
+pub struct Snapshot<'a, S: Storage> {
+  cache: Arc<Cache>,
+  storage: &'a S,
+}
+
+impl<'a, S: Storage> Snapshot<'a, S> {
+  pub fn revision(&self) -> Index {
+    self.cache.n()
+  }
+
+  pub fn query(&self) -> Result<Query> {
+    let cursor = self.storage.cursor()?;
+    let revision = self.cache.clone();
+    Ok(Query { cursor, revision })
+  }
+}
+
 /// ストレージ上に直列化された Stratified Hash Tree を表す木構造に対する操作を実装します。
 pub struct Slate<S: Storage> {
-  storage: Box<S>,
+  position: Position,
+  storage: S,
   latest_cache: Arc<Cache>,
 }
 
@@ -637,8 +459,8 @@ impl<S: Storage> Slate<S> {
   /// fn append_and_get(file: &PathBuf) -> Result<()>{
   ///   let storage = FileStorage::new(file)?;
   ///   let mut db = Slate::new(storage)?;
-  ///   let root = db.append(&vec![0u8, 1, 2, 3])?;
-  ///   assert_eq!(Some(vec![0u8, 1, 2, 3]), db.query()?.get(root.i)?.map(|x| x.as_ref().clone()));
+  ///   let root = db.append(&[0u8, 1, 2, 3])?;
+  ///   assert_eq!(Some(vec![0u8, 1, 2, 3]), db.snapshot().query()?.get(root.i)?.map(|x| x.as_ref().clone()));
   ///   Ok(())
   /// }
   ///
@@ -647,11 +469,9 @@ impl<S: Storage> Slate<S> {
   /// append_and_get(&path).expect("test failed");
   /// remove_file(path.as_path()).unwrap();
   /// ```
-  pub fn new(storage: S) -> Result<Slate<S>> {
-    let gen_cache = Arc::new(Cache::empty());
-    let mut db = Slate { storage: Box::new(storage), latest_cache: gen_cache };
-    db.init()?;
-    Ok(db)
+  pub fn new(mut storage: S) -> Result<Slate<S>> {
+    let (cache, position) = Self::boot(&mut storage)?;
+    Ok(Slate { position, storage, latest_cache: Arc::new(cache) })
   }
 
   /// 現在の木構造のルートノードを参照します。
@@ -675,67 +495,30 @@ impl<S: Storage> Slate<S> {
   }
 
   pub fn storage(&self) -> &S {
-    self.storage.as_ref()
+    &self.storage
   }
 
-  fn init(&mut self) -> Result<()> {
-    let mut cursor = self.storage.cursor()?;
-    let length = cursor.seek(io::SeekFrom::End(0))?;
-    match length {
-      0 => {
-        // マジックナンバーの書き込み
-        self.storage.write_all(&STORAGE_IDENTIFIER)?;
-        self.storage.write_u8(STORAGE_VERSION)?;
-        self.storage.flush()?;
-      }
-      1..=3 => return Err(FileIsNotContentsOfLMTHTree { message: "bad magic number" }),
-      _ => {
-        // マジックナンバーの確認
-        let mut buffer = [0u8; 4];
-        cursor.seek(io::SeekFrom::Start(0))?;
-        cursor.read_exact(&mut buffer)?;
-        if buffer[..3] != STORAGE_IDENTIFIER[..] {
-          return Err(FileIsNotContentsOfLMTHTree { message: "bad magic number" });
-        } else if !is_version_compatible(buffer[3]) {
-          return Err(IncompatibleVersion(buffer[3] >> 4, buffer[3] & 0x0F));
+  fn boot(storage: &mut dyn Storage) -> Result<(Cache, Position)> {
+    let (latest_entry, position) = storage.boot()?;
+    let cache = match latest_entry {
+      Some(entry) => {
+        // PBST ルートノードの読み込み
+        let mut cursor = storage.cursor()?;
+        let mut pbst_roots = Vec::with_capacity(entry.inodes.len());
+        for inode in entry.inodes.iter() {
+          let position = inode.left.position;
+          let i_expected = inode.left.i;
+          let entry = cursor.get(position, i_expected)?;
+          let Entry { enode, mut inodes } = entry;
+          let pbst_root = inodes.pop().map(PbstRoot::INode).unwrap_or(PbstRoot::ENode(enode));
+          pbst_roots.push(pbst_root);
         }
+        let model = NthGenHashTree::new(entry.enode.meta.address.i);
+        Cache::new(entry, pbst_roots, model)
       }
-    }
-
-    let length = cursor.seek(io::SeekFrom::End(0))?;
-    let new_cache = if length == 4 {
-      Cache::empty()
-    } else {
-      // 末尾のエントリを読み込み
-      back_to_safety(cursor.as_mut(), 4 + 8, "The first entry is corrupted.")?;
-      let offset = cursor.read_u32::<LittleEndian>()?;
-      back_to_safety(cursor.as_mut(), offset + 4, "The last entry is corrupted.")?;
-      let entry = read_entry(&mut cursor, 0)?;
-      if cursor.stream_position()? != length {
-        // 壊れたストレージから読み込んだ offset が、たまたまどこかの正しいエントリ境界を指していた場合、正しく
-        // 読み込めるが結果となる位置は末尾と一致しない。
-        let msg = "The last entry is corrupted.".to_string();
-        return Err(DamagedStorage(msg));
-      }
-
-      // PBST ルートノードの読み込み
-      let mut pbst_roots = Vec::with_capacity(entry.inodes.len());
-      for inode in entry.inodes.iter() {
-        let position = inode.left.position;
-        let i_expected = inode.left.i;
-        cursor.seek(SeekFrom::Start(position))?;
-        let Entry { enode, mut inodes } = read_entry_without_check(&mut cursor, position, i_expected)?;
-        let pbst_root = inodes.pop().map(PbstRoot::INode).unwrap_or(PbstRoot::ENode(enode));
-        pbst_roots.push(pbst_root);
-      }
-      let model = NthGenHashTree::new(entry.enode.meta.address.i);
-      Cache::new(entry, pbst_roots, model)
+      None => Cache::empty(),
     };
-
-    // キャッシュを更新
-    self.latest_cache = Arc::new(new_cache);
-
-    Ok(())
+    Ok((cache, position))
   }
 
   /// 指定された値をこの Slate に追加します。
@@ -750,7 +533,7 @@ impl<S: Storage> Slate<S> {
     }
 
     // 葉ノードの構築
-    let position = self.storage.size()?;
+    let position = self.position;
     let i = self.latest_cache.root().map(|node| node.i + 1).unwrap_or(1);
     let hash = Hash::from_bytes(value);
     let meta = MetaInfo::new(Address::new(i, 0, position), hash);
@@ -760,8 +543,7 @@ impl<S: Storage> Slate<S> {
     let mut inodes = Vec::<INode>::with_capacity(INDEX_SIZE as usize);
     let mut right_hash = enode.meta.hash;
     let generation = NthGenHashTree::new(i);
-    let mut right_to_left_inodes = generation.inodes();
-    right_to_left_inodes.reverse();
+    let right_to_left_inodes = generation.inodes();
     let mut pbst_roots = Vec::with_capacity(ceil_log2(i) as usize);
     for n in right_to_left_inodes.iter() {
       debug_assert_eq!(i, n.node.i);
@@ -791,8 +573,8 @@ impl<S: Storage> Slate<S> {
       if let Some(inode) = inodes.last() { (inode.meta.address.j, inode.meta.hash) } else { (0u8, enode.meta.hash) };
 
     // エントリを書き込んで状態を更新
-    let entry = Entry { enode, inodes };
-    write_entry(self.storage.as_mut(), &entry)?;
+    let entry = Entry::new(enode, inodes);
+    self.position = self.storage.put(self.position, &entry)?;
 
     // キャッシュを更新
     let cache = Cache(Some(CacheInner { last_entry: entry, pbst_roots, model: generation }));
@@ -801,461 +583,136 @@ impl<S: Storage> Slate<S> {
     Ok(Node::new(i, j, root_hash))
   }
 
-  pub fn query(&self) -> Result<Query> {
-    let cursor = self.storage.cursor()?;
-    let generation = self.latest_cache.clone();
-    Ok(Query { cursor, generation })
+  pub fn snapshot(&self) -> Snapshot<'_, S> {
+    Snapshot { cache: self.latest_cache.clone(), storage: &self.storage }
   }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalkDirection {
+  Left,
+  Right,
+  Both,
+  Stop,
+}
+
+#[derive(Debug)]
+pub struct AuthPath {
+  pub value: Value,
+  pub path: Vec<Node>,
 }
 
 pub struct Query {
   cursor: Box<dyn Cursor>,
-  generation: Arc<Cache>,
+  revision: Arc<Cache>,
 }
 
 impl Query {
-  /// このクエリーが対象としている木構造の世代 (スナップショットに相当) を参照します。
-  pub fn n(&self) -> Index {
-    self.generation.n()
+  /// このクエリーが対象としている木構造の版 (世代、スナップショットに相当) を参照します。
+  pub fn revision(&self) -> Index {
+    self.revision.n()
   }
 
-  /// 範囲外のインデックス (0 を含む) を指定した場合は `None` を返します。
-  pub fn get(&mut self, i: Index) -> Result<Option<Arc<Vec<u8>>>> {
-    if let Some(node) = Self::get_node(self.generation.as_ref(), &mut self.cursor, i, 0)? {
-      self.cursor.seek(io::SeekFrom::Start(node.address.position))?;
-      let entry = read_entry_without_check(&mut self.cursor, node.address.position, node.address.i)?;
-      let Entry { enode: ENode { payload, .. }, .. } = entry;
-      Ok(Some(payload.clone()))
+  pub fn walk_down<F, E>(&mut self, callback: &mut F) -> Result<()>
+  where
+    F: FnMut(Index, Index, u8, &Hash, Option<&Arc<Vec<u8>>>) -> std::result::Result<WalkDirection, E>,
+    E: std::error::Error + 'static,
+  {
+    let cache_opt = &self.revision.clone().0;
+    let cache = if let Some(cache) = cache_opt { cache } else { return Ok(()) };
+    let node_index = if cache.last_entry.inodes.is_empty() { 0 } else { cache.last_entry.inodes.len() };
+    self._walk_down(node_index, &cache.last_entry, callback)
+  }
+
+  fn _walk_down<F, E>(&mut self, node_index: usize, entry: &Entry, callback: &mut F) -> Result<()>
+  where
+    F: FnMut(Index, Index, u8, &Hash, Option<&Arc<Vec<u8>>>) -> std::result::Result<WalkDirection, E>,
+    E: std::error::Error + 'static,
+  {
+    let i = entry.enode.meta.address.i;
+    let (j, hash, value) = if node_index == 0 {
+      let node = &entry.enode;
+      (node.meta.address.j, &node.meta.hash, Some(&node.payload))
     } else {
-      Ok(None)
+      let node = &entry.inodes[node_index - 1];
+      (node.meta.address.j, &node.meta.hash, None)
+    };
+
+    let dir = (callback)(self.revision(), i, j, hash, value).map_err(|e| Error::WalkDown(Box::new(e)))?;
+
+    if node_index == 0 || dir == WalkDirection::Stop {
+      return Ok(());
     }
-  }
-
-  /// 葉ノード b_i の値を中間ノードのハッシュ値付きで取得します。
-  #[inline]
-  pub fn get_with_hashes(&mut self, i: Index) -> Result<Option<ValuesWithBranches>> {
-    self.get_values_with_hashes(i, 0)
-  }
-
-  /// 指定されたノード b_{i,j} をルートとする部分木に含まれているすべての値 (葉ノード) を中間ノードのハッシュ値
-  /// 付きで取得します。この結果から算出されるルートハッシュを使用して、値のデータが破損や改ざんされていないことを
-  /// 検証することができます。
-  ///
-  /// # Returns
-  /// 返値には範囲に含まれる 1 個以上の値と、b_{i,j} への経路から分岐したノードが含まれています。ここで得られる
-  /// 値の範囲は [model::range(i,j)](range) を使って算出することができます。b_{i,j} をルートとする
-  /// [部分木が完全二分木](model::is_pbst) の場合、返値の数は `1 << j` 個になります。完全二分木でない場合は
-  /// `1 << j` より少ない個数となります。
-  ///
-  /// `i` に 0 を含む範囲外のインデックスを指定した場合は `None` を返します。
-  ///
-  /// # Example
-  /// ```rust
-  /// use slate::{Slate, MemStorage, Hash};
-  /// use slate::model::{range, is_pbst};
-  ///
-  /// let mut db = Slate::new(MemStorage::new()).unwrap();
-  /// let mut latest_root_hash = Hash::from_bytes(&vec![]);
-  /// for i in 0u32..100 {
-  ///   let current_root = db.append(&i.to_le_bytes()).unwrap();
-  ///   latest_root_hash = current_root.hash;
-  /// }
-  /// let mut query = db.query().unwrap();
-  /// let values = query.get_values_with_hashes(40, 3).unwrap().unwrap();
-  /// assert!(is_pbst(40, 3));
-  /// assert_eq!(1 << 3, values.values.len());
-  /// assert_eq!(*range(40, 3).start(), values.values[0].i);
-  /// assert_eq!(*range(40, 3).end(), values.values[(1 << 3) - 1].i);
-  /// assert_eq!(latest_root_hash, values.root().hash);
-  /// ```
-  ///
-  pub fn get_values_with_hashes(&mut self, i: Index, j: u8) -> Result<Option<ValuesWithBranches>> {
-    let (last_entry, model) = if let Some(CacheInner { last_entry, pbst_roots: _, model }) = &self.generation.0 {
-      if i == 0 || i > model.n() {
-        return Ok(None);
-      }
-      (last_entry, model)
-    } else {
-      return Ok(None);
-    };
-    let root = match self.generation.root_ref() {
-      RootRef::INode(inode) => *inode,
-      RootRef::ENode(enode) => {
-        self.cursor.seek(SeekFrom::Start(enode.meta.address.position))?;
-        let Entry { enode: ENode { payload, .. }, .. } =
-          read_entry_without_check(&mut self.cursor, enode.meta.address.position, i)?;
-        return Ok(Some(ValuesWithBranches {
-          values: vec![Value { i, value: payload.as_ref().clone() }],
-          branches: vec![],
-        }));
-      }
-      RootRef::None => return Ok(None),
-    };
-    let path = match model.path_to(i, j) {
-      Some(path) => path,
-      None => return Ok(None),
-    };
-    debug_assert_eq!(model.root().i, root.meta.address.i);
-    debug_assert_eq!(model.root().j, root.meta.address.j);
-
-    // 目的のノードまで経路を移動しながら分岐のハッシュ値を取得する
-    let mut prev = root;
-    let mut inodes = last_entry.inodes.clone();
-    let mut branches = Vec::<Node>::with_capacity(INDEX_SIZE as usize);
-    for step in path.steps.iter().map(|s| s.step) {
-      // 左枝側のエントリの INode を読み込み (右枝側のノードは inodes に含まれている)
-      self.cursor.seek(SeekFrom::Start(prev.left.position))?;
-      let left_inodes = read_inodes(&mut self.cursor, prev.left.position)?;
-
-      // 左右どちらの枝が次のノードでどちらが分岐のノードかを判断
-      let (next, next_inodes, branch, branch_inodes) = if prev.left.i == step.i && prev.left.j == step.j {
-        (&prev.left, left_inodes, &prev.right, inodes)
+    if dir == WalkDirection::Right || dir == WalkDirection::Both {
+      self._walk_down(node_index - 1, entry, callback)?
+    }
+    if dir == WalkDirection::Left || dir == WalkDirection::Both {
+      let current = &entry.inodes[node_index - 1];
+      let left = self.cursor.get(current.left.position, current.left.i)?;
+      debug_assert_eq!(current.left.i, left.enode.meta.address.i);
+      debug_assert!(left.enode.meta.address.i < i);
+      let left_j = current.left.j;
+      let left_node_index = if current.left.j == 0 {
+        0
       } else {
-        debug_assert!(prev.right.i == step.i && prev.right.j == step.j);
-        (&prev.right, inodes, &prev.left, left_inodes)
-      };
-
-      // 分岐したノードのハッシュ値付きの情報を保存
-      if branch.j > 0 {
-        // INode として分岐したノードを参照して保存
-        if let Some(inode) = branch_inodes.iter().find(|n| n.meta.address.j == branch.j) {
-          debug_assert!(inode.meta.address == *branch);
-          branches.push(Node::for_node(&inode.meta));
-        } else {
-          return inconsistency(format!(
-            "in searching for b_{{{},{}}} in T_{}, branch inode b_{{{}, {}}} isn't included in {:?}",
-            i,
-            j,
-            self.n(),
-            branch.i,
-            branch.j,
-            branch_inodes
-          ));
+        match left.inodes.iter().position(|inode| inode.meta.address.j == left_j) {
+          Some(i) => i + 1,
+          None => inconsistency(format!(
+            "The node b_{{{},{}}} referenced as the right node of node b_{{{},{}}} isn't included in entry {} @ {}",
+            current.right.i,
+            current.right.j,
+            current.meta.address.i,
+            current.meta.address.j,
+            current.right.i,
+            current.right.position
+          ))?,
         }
-      } else {
-        // ENode として分岐したノードを読み込んで保存
-        self.cursor.seek(SeekFrom::Start(branch.position))?;
-        let entry = read_entry_without_check(&mut self.cursor, branch.position, branch.i)?;
-        branches.push(Node::for_node(&entry.enode.meta));
-      }
-
-      if next.j == 0 {
-        debug_assert_eq!((i, j), (next.i, next.j), "branch={branch:?}");
-        self.cursor.seek(SeekFrom::Start(next.position))?;
-        let Entry { enode: ENode { payload, .. }, .. } =
-          read_entry_without_check(&mut self.cursor, next.position, next.i)?;
-        let values = vec![Value { i: next.i, value: payload.as_ref().clone() }];
-        return Ok(Some(ValuesWithBranches::new(values, branches)));
-      }
-
-      // 次のノードに移動
-      if let Some(inode) = next_inodes.iter().find(|node| node.meta.address == *next) {
-        prev = *inode;
-        inodes = next_inodes;
-      } else {
-        return inconsistency(format!(
-          "in searching for ({},{}), the inode ({}, {}) on the route isn't included in {:?}",
-          i, j, next.i, next.j, next_inodes
-        ));
-      }
-    }
-
-    // 目的のノードに含まれている値を取得する
-    let values = self.get_values_belonging_to(&prev)?;
-    Ok(Some(ValuesWithBranches::new(values, branches)))
-  }
-
-  fn get_node(generation: &Cache, cursor: &mut Box<dyn Cursor>, i: Index, j: u8) -> Result<Option<MetaInfo>> {
-    if let Some((position, _)) = Self::get_entry_position(generation, cursor, i, false)? {
-      cursor.seek(io::SeekFrom::Start(position))?;
-      if j == 0 {
-        let entry = read_entry_without_check(cursor, position, i)?;
-        Ok(Some(entry.enode.meta))
-      } else {
-        let inodes = read_inodes(cursor, position)?;
-        Ok(inodes.iter().find(|inode| inode.meta.address.j == j).map(|inode| inode.meta))
-      }
-    } else {
-      Ok(None)
-    }
-  }
-
-  /// 指定された `inode` をルートとする部分木に含まれているすべての値を参照します。読み出し用のカーソルは `inode`
-  /// の位置を指している必要はありません。
-  fn get_values_belonging_to(&mut self, inode: &INode) -> Result<Vec<Value>> {
-    // inode を左枝方向に葉に到達するまで移動
-    let mut mover = *inode;
-    while mover.left.j > 0 {
-      self.cursor.seek(SeekFrom::Start(mover.left.position))?;
-      let inodes = read_inodes(&mut self.cursor, mover.left.position)?;
-      mover = match inodes.iter().find(|node| node.meta.address.j == mover.left.j) {
-        Some(inode) => *inode,
-        None => panic!(),
       };
-    }
-
-    let range = range(inode.meta.address.i, inode.meta.address.j);
-    let (i0, i1) = (*range.start(), *range.end());
-    let mut values = Vec::<Value>::with_capacity((i1 - i0) as usize);
-    let mut i = mover.left.i;
-    self.cursor.seek(SeekFrom::Start(mover.left.position))?;
-    while i <= i1 {
-      let Entry { enode: ENode { meta: node, payload }, .. } = read_entry_without_check_to_end(&mut self.cursor, i)?;
-      debug_assert!(node.address.i == i);
-      values.push(Value { i, value: payload.as_ref().clone() });
-      i += 1;
-    }
-    Ok(values)
-  }
-
-  /// `i` 番目のエントリの位置を参照します。この検索は現在のルートノードを基準にした探索を行います。
-  fn get_entry_position(
-    generation: &Cache,
-    cursor: &mut Box<dyn Cursor>,
-    i: Index,
-    with_branch: bool,
-  ) -> Result<Option<(Index, Vec<MetaInfo>)>> {
-    match &generation.root_ref() {
-      RootRef::INode(root) => {
-        let root = *(*root);
-        search_entry_position(cursor, &root, i, with_branch)
-      }
-      RootRef::ENode(root) if root.meta.address.i == i => Ok(Some((root.meta.address.position, vec![]))),
-      _ => Ok(None),
-    }
-  }
-}
-
-/// 指定されたカーソルの現在の位置からエントリを読み込みます。
-/// 正常終了時のカーソルは次のエントリを指しています。
-fn read_entry<C>(r: &mut C, expected_index: Index) -> Result<Entry>
-where
-  C: io::Read + io::Seek,
-{
-  let position = r.stream_position()?;
-  let mut hasher = HighwayHasher::new(Key(CHECKSUM_HW64_KEY));
-  let mut r = HashRead::new(r, &mut hasher);
-  let entry = read_entry_without_check(&mut r, position, expected_index)?;
-
-  // オフセットの検証
-  let offset = r.length();
-  let trailer_offset = r.read_u32::<LittleEndian>()?;
-  if offset != trailer_offset as u64 {
-    return Err(IncorrectEntryHeadOffset { expected: trailer_offset, actual: offset });
-  }
-
-  // チェックサムの検証
-  let checksum = r.finish();
-  let trailer_checksum = r.read_u64::<LittleEndian>()?;
-  if checksum != trailer_checksum {
-    let length = offset as u32 + 4 + 8;
-    return Err(ChecksumVerificationFailed { at: position, length, expected: trailer_checksum, actual: checksum });
-  }
-
-  Ok(entry)
-}
-
-/// 指定されたカーソルの現在の位置から checksum による検証なしでエントリを読み込みます。正常終了時のカーソルの位置は
-/// 次のエントリの戦闘を指しています。
-fn read_entry_without_check_to_end<C>(r: &mut C, i_expected: Index) -> Result<Entry>
-where
-  C: io::Read + io::Seek,
-{
-  let position = r.stream_position()?;
-  let entry = read_entry_without_check(r, position, i_expected)?;
-  r.seek(SeekFrom::Current(4 /* offset */ + 8 /* checksum */))?;
-  Ok(entry)
-}
-
-/// 指定されたカーソルの現在の位置からエントリを読み込みます。トレイラーの offset と checksum は読み込まれない
-/// ため、正常終了時のカーソルは offset の位置を指しています。
-fn read_entry_without_check(r: &mut dyn io::Read, position: u64, expected_index: Index) -> Result<Entry> {
-  let mut hash = [0u8; HASH_SIZE];
-
-  // 中間ノードの読み込み
-  let inodes = read_inodes(r, position)?;
-  let i = inodes.first().map(|inode| inode.meta.address.i).unwrap_or(1);
-  if i != expected_index && expected_index != 0 {
-    return Err(Error::IncorrectNodeBoundary { at: position });
-  }
-
-  // 葉ノードの読み込み
-  let payload_size = r.read_u32::<LittleEndian>()? & MAX_PAYLOAD_SIZE as u32;
-  let mut payload = vec![0u8; payload_size as usize];
-  r.read_exact(&mut payload)?;
-  r.read_exact(&mut hash)?;
-  let enode = ENode { meta: MetaInfo::new(Address::new(i, 0, position), Hash::new(hash)), payload: Arc::new(payload) };
-
-  Ok(Entry { enode, inodes })
-}
-
-/// 指定されたカーソルの現在の位置をエントリの先頭としてすべての `INode` を読み込みます。正常終了した場合、カーソル
-/// 位置は最後の `INode` を読み込んだ直後を指しています。
-fn read_inodes(r: &mut dyn io::Read, position: u64) -> Result<Vec<INode>> {
-  let mut hash = [0u8; HASH_SIZE];
-  let i = r.read_u64::<LittleEndian>()?;
-  let inode_count = r.read_u8()?;
-  let mut right_j = 0u8;
-  let mut inodes = Vec::<INode>::with_capacity(inode_count as usize);
-  for _ in 0..inode_count as usize {
-    let j = (r.read_u8()? & (INDEX_SIZE - 1)) + 1; // 下位 6-bit のみを使用
-    let left_position = r.read_u64::<LittleEndian>()?;
-    let left_i = r.read_u64::<LittleEndian>()?;
-    let left_j = r.read_u8()?;
-    r.read_exact(&mut hash)?;
-    inodes.push(INode {
-      meta: MetaInfo::new(Address::new(i, j, position), Hash::new(hash)),
-      left: Address::new(left_i, left_j, left_position),
-      right: Address::new(i, right_j, position),
-    });
-    right_j = j;
-  }
-  Ok(inodes)
-}
-
-/// 指定されたカーソルにエントリを書き込みます。
-/// このエントリに対して書き込みが行われた長さを返します。
-fn write_entry<W: Write>(writer: &mut W, e: &Entry) -> Result<usize> {
-  debug_assert!(e.enode.payload.len() <= MAX_PAYLOAD_SIZE);
-  debug_assert!(e.inodes.len() <= 0xFF);
-
-  let mut buffer = Vec::with_capacity(1024);
-  let mut hasher = HighwayHasher::new(Key(CHECKSUM_HW64_KEY));
-  let mut w = HashWrite::new(&mut buffer, &mut hasher);
-
-  // 中間ノードの書き込み
-  w.write_u64::<LittleEndian>(e.enode.meta.address.i)?;
-  w.write_u8(e.inodes.len() as u8)?;
-  for i in &e.inodes {
-    debug_assert_eq!((i.meta.address.j - 1) & (INDEX_SIZE - 1), i.meta.address.j - 1);
-    w.write_u8((i.meta.address.j - 1) & (INDEX_SIZE - 1))?; // 下位 6-bit のみ保存
-    w.write_u64::<LittleEndian>(i.left.position)?;
-    w.write_u64::<LittleEndian>(i.left.i)?;
-    w.write_u8(i.left.j)?;
-    w.write_all(&i.meta.hash.value)?;
-  }
-
-  // 葉ノードの書き込み
-  w.write_u32::<LittleEndian>(e.enode.payload.len() as u32)?;
-  w.write_all(&e.enode.payload)?;
-  w.write_all(&e.enode.meta.hash.value)?;
-
-  // エントリ先頭までのオフセットを書き込み
-  w.write_u32::<LittleEndian>(w.length() as u32)?;
-
-  // チェックサムの書き込み
-  w.write_u64::<LittleEndian>(w.finish())?;
-  w.flush()?;
-
-  writer.write_all(&buffer)?;
-  writer.flush()?;
-  Ok(buffer.len())
-}
-
-/// `root` に指定された中間ノードを部分木構造のルートとして b_{i,*} に該当する葉ノードと中間ノードを含んでいる
-/// エントリのストレージ内での位置を取得します。該当するエントリが存在しない場合は `None` を返します。
-///
-/// `with_branch` に true を指定した場合、返値には `root` から検索対象のノードに至るまでの分岐先のハッシュ値を
-/// 持つノードが含まれます。これはハッシュツリーからハッシュ付きで値を参照するための動作です。false を指定した場合は
-/// 長さ 0 の `Vec` を返します。
-///
-fn search_entry_position<C>(
-  r: &mut C,
-  root: &INode,
-  i: Index,
-  with_branch: bool,
-) -> Result<Option<(u64, Vec<MetaInfo>)>>
-where
-  C: io::Read + io::Seek,
-{
-  if root.meta.address.i == i {
-    // 指定されたルートノードが検索対象のノードの場合
-    return Ok(Some((root.meta.address.position, vec![])));
-  } else if i == 0 || i > root.meta.address.i {
-    // インデックス 0 の特殊値を持つノードは明示的に存在しない
-    return Ok(None);
-  }
-
-  let mut branches = Vec::<MetaInfo>::with_capacity(INDEX_SIZE as usize);
-  let mut mover = *root;
-  for _ in 0..INDEX_SIZE {
-    // 次のノードのアドレスを参照
-    let next = if i <= mover.left.i {
-      read_branch(r, &mover.right, with_branch, &mut branches)?;
-      mover.left
-    } else if i <= mover.meta.address.i {
-      read_branch(r, &mover.left, with_branch, &mut branches)?;
-      mover.right
-    } else {
-      // 有効範囲外
-      return Ok(None);
-    };
-
-    // 次のノードのアドレスが検索対象ならそのエントリの位置を返す
-    if next.i == i {
-      return Ok(Some((next.position, branches)));
-    }
-
-    // 末端に到達している場合は発見できなかったことを意味する
-    if next.j == 0 {
-      return Ok(None);
-    }
-
-    // b_{i,*} の中間ノードをロードして次の中間ノードを取得
-    mover = read_inode(r, &next)?;
-  }
-
-  fn read_inode<C>(r: &mut C, addr: &Address) -> Result<INode>
-  where
-    C: io::Read + io::Seek,
-  {
-    debug_assert_ne!(0, addr.j);
-    r.seek(io::SeekFrom::Start(addr.position))?;
-    let inodes = read_inodes(r, addr.position)?;
-    let inode = inodes.iter().find(|inode| inode.meta.address.j == addr.j);
-    if let Some(inode) = inode {
-      Ok(*inode)
-    } else {
-      // 内部の木構造とストレージ上のデータが矛盾している
-      inconsistency(format!("entry i={} in storage doesn't contain an inode at specified level j={}", addr.i, addr.j))
-    }
-  }
-
-  fn read_branch<C>(r: &mut C, addr: &Address, with_branch: bool, branches: &mut Vec<MetaInfo>) -> Result<()>
-  where
-    C: io::Read + io::Seek,
-  {
-    if with_branch {
-      let branch = if addr.j == 0 {
-        r.seek(io::SeekFrom::Start(addr.position))?;
-        let entry = read_entry_without_check(r, addr.position, addr.i)?;
-        entry.enode.meta
-      } else {
-        read_inode(r, addr)?.meta
-      };
-      branches.push(branch);
+      self._walk_down(left_node_index, &left, callback)?
     }
     Ok(())
   }
 
-  // ストレージ上のデータのポインタが循環参照を起こしている
-  inconsistency(format!(
-    "The maximum hop count was exceeded before reaching node b_{} from node b_{{{},{}}}.\
-     The data on the storage probably have circular references.",
-    i, root.meta.address.i, root.meta.address.j
-  ))
-}
+  /// 指定されたインデックスの値を参照します。
+  /// 0 を含む範囲外のインデックスを指定した場合は `None` を返します。
+  pub fn get(&mut self, i: Index) -> Result<Option<Arc<Vec<u8>>>> {
+    if i == 0 || i > self.revision.n() {
+      return Ok(None);
+    }
+    let mut value = None;
+    self.walk_down(&mut |_n, b_i, b_j, _hash, leaf_value: Option<&Arc<Vec<u8>>>| {
+      if b_i == i {
+        if b_j == 0 {
+          if let Some(v) = leaf_value {
+            value = Some(v.clone());
+            println!("{_n}: i={i} = b_i={b_i}, b_j={b_j} == 0: Stop");
+            Ok(WalkDirection::Stop)
+          } else {
+            inconsistency(format!("The value was not passed at the leaf node b_{b_i} reached"))
+          }
+        } else {
+          println!("{_n}: i={i} = b_i={b_i}, b_j={b_j} != 0: Right");
+          Ok(WalkDirection::Right)
+        }
+      } else {
+        let ((_il, _jl), (ir, jr)) = subnodes(b_i, b_j);
+        if contains(ir, jr, i) { Ok(WalkDirection::Right) } else { Ok(WalkDirection::Left) }
+      }
+    })?;
+    Ok(value)
+  }
 
-/// 指定されたカーソルを現在の位置から `distance` バイト前方に移動します。移動先がカーソルの先頭を超える場合は
-/// `if_err` をメッセージとしたエラーを発生します。
-#[inline]
-fn back_to_safety(cursor: &mut dyn Cursor, distance: u32, if_err: &'static str) -> Result<u64> {
-  let from = cursor.stream_position()?;
-  let to = from - distance as u64;
-  if to < STORAGE_IDENTIFIER.len() as u64 + 1 {
-    Err(DamagedStorage(format!("{if_err} (cannot move position from {from} to {to})")))
-  } else {
-    Ok(cursor.seek(io::SeekFrom::Current(-(distance as i64)))?)
+  // 指定されたデータ b_i とその認証パスを取得します。
+  pub fn get_authentication_path(&mut self, _i: Index) -> Result<Option<AuthPath>> {
+    unimplemented!()
+  }
+
+  // 指定された範囲 [i0, i1] (両端を含む) のエントリを取得します。
+  pub fn scan<F>(&self, _i0: Index, _i1: Index, _callback: &mut F)
+  where
+    F: FnMut(Entry),
+  {
+    unimplemented!()
   }
 }
 

--- a/src/model/test.rs
+++ b/src/model/test.rs
@@ -34,7 +34,7 @@ fn test_generation() {
   // 高さ j の完全二分木の次のケース
   let post_pbt = |j: u8| -> X { X((1 << j) + 1, vec![j + 1], vec![j + 1], vec![(1 << j, j), ((1 << j) + 1, 0)]) };
 
-  for X(n, inode_js, ephemeral_js, pbst_roots) in vec![
+  for X(n, mut inode_js, ephemeral_js, pbst_roots) in vec![
     X(1, vec![], vec![], vec![(1u64, 0u8)]),
     X(2, vec![1u8], vec![], vec![(2, 1)]),
     X(3, vec![2], vec![2u8], vec![(2, 1), (3, 0)]),
@@ -79,6 +79,7 @@ fn test_generation() {
     assert_eq!(expected, actual);
 
     // n-th 世代の中間ノード
+    inode_js.reverse();
     let expected = inode_js.iter().map(|j| Node::new(n, *j)).collect::<Vec<Node>>();
     let actual = generation.inodes().iter().map(|i| i.node).collect::<Vec<Node>>();
     assert_eq!(expected, actual);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,389 @@
+use crate::checksum::HashWrite;
+use crate::error::Error;
+use crate::error::Error::*;
+use crate::{Address, ENode, Entry, Hash, INDEX_SIZE, INode, MAX_PAYLOAD_SIZE, MetaInfo};
+use crate::{Index, Result};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use highway::{HighwayHasher, Key};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LockResult, RwLock};
+
+#[cfg(test)]
+mod test;
+
+pub type Position = u64;
+
+/// ハッシュツリーのエントリを保存するために抽象化されたストレージです。
+pub trait Storage {
+  // 起動時に呼び出され、最新のエントリと、次のエントリの位置を返します。
+  fn boot(&mut self) -> Result<(Option<Entry>, Position)>;
+
+  // 指定された位置にエントリの保存します。
+  // 次のエントリの位置を返します。
+  fn put(&mut self, position: Position, entry: &Entry) -> Result<Position>;
+
+  // エントリを読み込むためのカーソルを参照します。
+  fn cursor(&self) -> Result<Box<dyn Cursor>>;
+}
+
+/// ストレージからエントリを読み込むためのカーソルです。
+pub trait Cursor {
+  // 指定された位置からエントリを参照して返します。
+  fn get(&mut self, position: Position, expected_index: Index) -> Result<Entry>;
+}
+
+/// ローカルファイルシステムのパスをストレージとして使用する実装です。
+pub struct FileStorage {
+  /// 読み出し時にオープンするためのこのファイルのパス。
+  path: PathBuf,
+  /// 読み出しようにオープンするためのオプション。
+  read_options: OpenOptions,
+  /// 書き込み専用で、必ずファイルの末尾を指している。
+  file: File,
+  /// このファイルの長さ
+  position: u64,
+}
+
+impl FileStorage {
+  pub fn new<P: AsRef<Path>>(path: P) -> Result<FileStorage> {
+    Self::with_options(
+      path,
+      File::options().read(true).append(true).create(true).truncate(false).clone(),
+      File::options().read(true).write(false).create(false).truncate(false).clone(),
+    )
+  }
+
+  pub fn with_read_only<P: AsRef<Path>>(path: P) -> Result<FileStorage> {
+    Self::with_options(
+      path,
+      File::options().read(true).write(false).create(false).truncate(false).clone(),
+      File::options().read(true).write(false).create(false).truncate(false).clone(),
+    )
+  }
+
+  pub fn with_options<P: AsRef<Path>>(
+    path: P,
+    write_options: OpenOptions,
+    read_options: OpenOptions,
+  ) -> Result<FileStorage> {
+    let path = path.as_ref().to_path_buf();
+    match write_options.open(&path) {
+      Ok(file) => {
+        let length = file.metadata()?.len();
+        Ok(Self { path, read_options, file, position: length })
+      }
+      Err(err) => Err(Error::FailedToOpenLocalFile {
+        file: path.to_str().map(|s| s.to_string()).unwrap_or(path.to_string_lossy().to_string()),
+        message: err.to_string(),
+      }),
+    }
+  }
+}
+
+impl Storage for FileStorage {
+  fn cursor(&self) -> Result<Box<dyn Cursor>> {
+    let file = self.read_options.open(&self.path)?;
+    Ok(Box::new(FileCursor::new(file)))
+  }
+
+  fn boot(&mut self) -> Result<(Option<Entry>, Position)> {
+    let (entry, position) = boot(&mut self.file)?;
+    self.position = position;
+    Ok((entry, position))
+  }
+
+  fn put(&mut self, position: Position, entry: &Entry) -> Result<Position> {
+    debug_assert_eq!(self.position, position);
+    let length = write_entry(&mut self.file, entry)?;
+    self.file.flush()?;
+    self.position += length as u64;
+    Ok(self.position)
+  }
+}
+
+struct FileCursor {
+  file: File,
+}
+
+impl FileCursor {
+  pub fn new(file: File) -> Self {
+    FileCursor { file }
+  }
+}
+
+impl Cursor for FileCursor {
+  fn get(&mut self, position: Position, expected_index: Index) -> Result<Entry> {
+    self.file.seek(SeekFrom::Current(position as i64))?;
+    read_entry(&mut self.file, Some(expected_index))
+  }
+}
+
+/// メモリ上の領域をストレージとして使用する実装です。`drop()` された時点で記録していた内容が消滅するため、テストや
+/// 調査での使用を想定しています。
+pub struct MemStorage {
+  buffer: Arc<RwLock<Vec<u8>>>,
+}
+
+impl MemStorage {
+  /// 揮発性メモリを使用するストレージを構築します。
+  pub fn new() -> MemStorage {
+    Self::with(Arc::new(RwLock::new(Vec::<u8>::with_capacity(4 * 1024))))
+  }
+
+  /// 指定されたアトミック参照カウント/RWロック付きの可変バッファを使用するストレージを構築します。これは調査の目的で
+  /// 外部からストレージの内容を参照することを想定しています。
+  pub fn with(buffer: Arc<RwLock<Vec<u8>>>) -> MemStorage {
+    MemStorage { buffer }
+  }
+}
+
+impl Default for MemStorage {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl Storage for MemStorage {
+  fn boot(&mut self) -> Result<(Option<Entry>, Position)> {
+    let mut guard = lock2io(self.buffer.write())?;
+    let mut cursor = io::Cursor::new(&mut *guard);
+    boot(&mut cursor)
+  }
+  fn put(&mut self, position: Position, entry: &Entry) -> Result<Position> {
+    debug_assert_eq!(lock2io(self.buffer.read())?.len() as Position, position);
+    let len = {
+      let mut guard = lock2io(self.buffer.write())?;
+      let mut cursor = io::Cursor::new(&mut *guard);
+      cursor.seek(SeekFrom::End(0))?;
+      write_entry(&mut cursor, entry)?
+    };
+    debug_assert_eq!(lock2io(self.buffer.read())?.len() as Position, position + len as Position);
+    Ok(position + len as Position)
+  }
+  fn cursor(&self) -> Result<Box<dyn Cursor>> {
+    Ok(Box::new(MemCursor { buffer: self.buffer.clone() }))
+  }
+}
+
+struct MemCursor {
+  buffer: Arc<RwLock<Vec<u8>>>,
+}
+
+impl Cursor for MemCursor {
+  fn get(&mut self, position: Position, expected_index: Index) -> Result<Entry> {
+    let guard = lock2io(self.buffer.read())?;
+    let mut cursor = io::Cursor::new(guard.as_slice());
+    cursor.seek(SeekFrom::Start(position))?;
+    read_entry_without_check(&mut cursor, position, Some(expected_index))
+  }
+}
+
+/// `LockResult` を `io::Result` に変換します。
+#[inline]
+fn lock2io<T>(result: LockResult<T>) -> std::io::Result<T> {
+  result.map_err(|err| std::io::Error::other(err.to_string()))
+}
+
+/// slate ファイルの先頭に記録される 3 バイトの識別子を表す定数です。値は Unicode でのdeciduous tree 🌲 (U+1F332)
+/// に由来します。
+pub const STORAGE_IDENTIFIER: [u8; 3] = [0x01u8, 0xF3, 0x33];
+
+/// 識別子に続いて配置される、この実装におけるストレージフォーマットのバージョンです。現在は 1 を使用します。
+pub const STORAGE_VERSION: u8 = 1;
+
+/// 使用しようとしているストレージと互換性があるかを確認します。
+pub(crate) fn is_version_compatible(version: u8) -> bool {
+  version <= STORAGE_VERSION
+}
+
+fn boot<C>(cursor: &mut C) -> Result<(Option<Entry>, Position)>
+where
+  C: Write + Read + Seek,
+{
+  match cursor.seek(SeekFrom::End(0))? {
+    0 => {
+      // マジックナンバーの書き込み
+      cursor.write_all(&STORAGE_IDENTIFIER)?;
+      cursor.write_u8(STORAGE_VERSION)?;
+      cursor.flush()?;
+    }
+    1..=3 => return Err(FileIsNotContentsOfLMTHTree { message: "bad magic number" }),
+    _ => {
+      // マジックナンバーの確認
+      let mut buffer = [0u8; 4];
+      cursor.seek(SeekFrom::Start(0))?;
+      cursor.read_exact(&mut buffer)?;
+      if buffer[..3] != STORAGE_IDENTIFIER[..] {
+        return Err(FileIsNotContentsOfLMTHTree { message: "bad magic number" });
+      } else if !is_version_compatible(buffer[3]) {
+        return Err(IncompatibleVersion(buffer[3] >> 4, buffer[3] & 0x0F));
+      }
+    }
+  }
+
+  let next_position = cursor.seek(SeekFrom::End(0))?;
+  let latest_entry = if next_position == 4 {
+    None
+  } else {
+    // 末尾のエントリを読み込み
+    back_to_safety(cursor, 4 /* offset */ + 8 /* checksum */, "The first entry is corrupted.")?;
+    let offset = cursor.read_u32::<LittleEndian>()?;
+    back_to_safety(cursor, offset + 4 /* offset */, "The last entry is corrupted.")?;
+    let entry = read_entry(cursor, None)?;
+    if cursor.stream_position()? != next_position {
+      // 壊れたストレージから読み込んだ offset が、たまたまどこかの正しいエントリ境界を指していた場合、正しく
+      // 読み込めるが結果となる位置は末尾と一致しない。
+      let msg = "The last entry is corrupted.".to_string();
+      return Err(DamagedStorage(msg));
+    }
+
+    Some(entry)
+  };
+
+  Ok((latest_entry, next_position))
+}
+
+/// 指定されたカーソルを現在の位置から `distance` バイト前方に移動します。移動先がカーソルの先頭を超える場合は
+/// `if_err` をメッセージとしたエラーを発生します。
+#[inline]
+fn back_to_safety<R>(cursor: &mut R, distance: u32, if_err: &'static str) -> Result<u64>
+where
+  R: io::Read + io::Seek,
+{
+  let from = cursor.stream_position()?;
+  if from < STORAGE_IDENTIFIER.len() as u64 + 1 + distance as u64 {
+    Err(DamagedStorage(format!("{if_err} (cannot move {distance} bytes backword from the current position {from})")))
+  } else {
+    Ok(cursor.seek(io::SeekFrom::Current(-(distance as i64)))?)
+  }
+}
+
+/// HighwayHash でチェックサム用のハッシュ値を生成するためのキー (256-bit 固定値)。
+pub(crate) const CHECKSUM_HW64_KEY: [u64; 4] =
+  [0xFA5015F2E22BCFC6u64, 0xCE5A4ED9A4025C80, 0x16B9731717F6315E, 0x0F34D06AE93BD8E9];
+
+/// 指定されたカーソルの現在の位置からエントリを読み込みます。
+/// 正常終了時のカーソルは次のエントリを指しています。
+fn read_entry<R>(r: &mut R, expected_index: Option<Index>) -> Result<Entry>
+where
+  R: io::Read + io::Seek,
+{
+  use crate::checksum::HashRead;
+  use highway::{HighwayHasher, Key};
+
+  let position = r.stream_position()?;
+  let mut hasher = HighwayHasher::new(Key(CHECKSUM_HW64_KEY));
+  let mut r = HashRead::new(r, &mut hasher);
+  let entry = read_entry_without_check(&mut r, position, expected_index)?;
+
+  // オフセットの検証
+  let offset = r.length();
+  let trailer_offset = r.read_u32::<LittleEndian>()?;
+  if offset != trailer_offset as u64 {
+    return Err(IncorrectEntryHeadOffset { expected: trailer_offset, actual: offset });
+  }
+
+  // チェックサムの検証
+  let checksum = r.finish();
+  let trailer_checksum = r.read_u64::<LittleEndian>()?;
+  if checksum != trailer_checksum {
+    let length = offset as u32 + 4 + 8;
+    return Err(ChecksumVerificationFailed { at: position, length, expected: trailer_checksum, actual: checksum });
+  }
+
+  Ok(entry)
+}
+
+/// 指定されたカーソルの現在の位置からエントリを読み込みます。トレイラーの offset と checksum は読み込まれない
+/// ため、正常終了時のカーソルは offset の位置を指しています。
+fn read_entry_without_check<R>(r: &mut R, position: Position, expected_index: Option<Index>) -> Result<Entry>
+where
+  R: io::Read,
+{
+  let mut hash = [0u8; Hash::SIZE];
+
+  // 中間ノードの読み込み
+  let inodes = read_inodes(r, position)?;
+  let i = inodes.first().map(|inode| inode.meta.address.i).unwrap_or(1);
+  if expected_index.is_some_and(|expected| i != expected) {
+    return Err(Error::IncorrectNodeBoundary { at: position });
+  }
+
+  // 葉ノードの読み込み
+  let payload_size = r.read_u32::<LittleEndian>()? & MAX_PAYLOAD_SIZE as u32;
+  let mut payload = vec![0u8; payload_size as usize];
+  r.read_exact(&mut payload)?;
+  r.read_exact(&mut hash)?;
+  let enode = ENode { meta: MetaInfo::new(Address::new(i, 0, position), Hash::new(hash)), payload: Arc::new(payload) };
+
+  Ok(Entry::new(enode, inodes))
+}
+
+/// 指定されたカーソルの現在の位置をエントリの先頭としてすべての `INode` を読み込みます。正常終了した場合、カーソル
+/// 位置は最後の `INode` を読み込んだ直後を指しています。
+fn read_inodes<R>(r: &mut R, position: Position) -> Result<Vec<INode>>
+where
+  R: io::Read,
+{
+  let mut hash = [0u8; Hash::SIZE];
+  let i = r.read_u64::<LittleEndian>()?;
+  let inode_count = r.read_u8()? as usize;
+  let mut right_j = 0u8;
+  let mut inodes = Vec::<INode>::with_capacity(inode_count);
+  for _ in 0..inode_count {
+    let j = (r.read_u8()? & (INDEX_SIZE - 1)) + 1; // 下位 6-bit のみを使用
+    let left_position = r.read_u64::<LittleEndian>()?;
+    let left_i = r.read_u64::<LittleEndian>()?;
+    let left_j = r.read_u8()?;
+    r.read_exact(&mut hash)?;
+    inodes.push(INode {
+      meta: MetaInfo::new(Address::new(i, j, position), Hash::new(hash)),
+      left: Address::new(left_i, left_j, left_position),
+      right: Address::new(i, right_j, position),
+    });
+    right_j = j;
+  }
+  Ok(inodes)
+}
+
+/// 指定されたカーソルにエントリを書き込みます。
+/// このエントリに対して書き込みが行われた長さを返します。
+pub fn write_entry<W: Write>(writer: &mut W, e: &Entry) -> Result<usize> {
+  debug_assert!(e.enode.payload.len() <= MAX_PAYLOAD_SIZE);
+  debug_assert!(e.inodes.len() <= 0xFF);
+
+  let mut buffer = Vec::with_capacity(1024);
+  let mut hasher = HighwayHasher::new(Key(CHECKSUM_HW64_KEY));
+  let mut w = HashWrite::new(&mut buffer, &mut hasher);
+
+  // 中間ノードの書き込み
+  w.write_u64::<LittleEndian>(e.enode.meta.address.i)?;
+  w.write_u8(e.inodes.len() as u8)?;
+  for i in &e.inodes {
+    debug_assert_eq!((i.meta.address.j - 1) & (INDEX_SIZE - 1), i.meta.address.j - 1);
+    debug_assert_eq!(Hash::SIZE, i.meta.hash.value.len());
+    w.write_u8((i.meta.address.j - 1) & (INDEX_SIZE - 1))?; // 下位 6-bit のみ保存
+    w.write_u64::<LittleEndian>(i.left.position)?;
+    w.write_u64::<LittleEndian>(i.left.i)?;
+    w.write_u8(i.left.j)?;
+    w.write_all(&i.meta.hash.value)?;
+  }
+
+  // 葉ノードの書き込み
+  w.write_u32::<LittleEndian>(e.enode.payload.len() as u32)?;
+  w.write_all(&e.enode.payload)?;
+  w.write_all(&e.enode.meta.hash.value)?;
+
+  // エントリ先頭までのオフセットを書き込み
+  w.write_u32::<LittleEndian>(w.length() as u32)?;
+
+  // チェックサムの書き込み
+  w.write_u64::<LittleEndian>(w.finish())?;
+  w.flush()?;
+
+  writer.write_all(&buffer)?;
+  writer.flush()?;
+  Ok(buffer.len())
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,16 +1,11 @@
-use std::env::temp_dir;
-use std::hash::BuildHasher;
-use std::hash::Hasher;
-use std::io;
-use std::io::{ErrorKind, Seek};
-use std::io::{SeekFrom, Write};
-use std::path::{MAIN_SEPARATOR, PathBuf};
-use std::thread::{JoinHandle, spawn};
-
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use highway::{HighwayBuildHasher, Key};
 use mt19937::MT19937;
 use rand::RngCore;
+use std::env::temp_dir;
+use std::fs::OpenOptions;
+use std::io::ErrorKind;
+use std::path::{MAIN_SEPARATOR, PathBuf};
+use std::sync::RwLock;
+use std::thread::{JoinHandle, spawn};
 
 use crate::model::ceil_log2;
 use crate::*;
@@ -24,7 +19,7 @@ fn test_multi_threaded_query() {
     for _ in 0..handles.capacity() {
       let cloned_db = db.clone();
       handles.push(spawn(move || {
-        let mut query = cloned_db.query().unwrap();
+        let mut query = cloned_db.snapshot().query().unwrap();
         for i in 0..=N {
           if let Some(value) = query.get(i).unwrap() {
             assert!(i > 0 || i <= n);
@@ -44,73 +39,6 @@ fn test_multi_threaded_query() {
   }
 }
 
-/// 単一のエントリの直列化と復元をテストします。
-#[test]
-fn entry_serialization() -> Result<()> {
-  for entry in sample_entries() {
-    // メモリ上に書き込みを行いサイズを確認
-    let mut buffer = Vec::new();
-    let write_length = write_entry(&mut buffer, &entry)?;
-    assert_eq!(write_length, buffer.len());
-
-    // チェックサムが実際に書き込まれたバイナリに対するものであることを確認
-    verify_checksum(&buffer);
-
-    let expected = entry;
-
-    // 中間ノードのみを読み出して同一かを確認
-    let mut cursor = io::Cursor::new(buffer.clone());
-    cursor.set_position(0);
-    let inodes = read_inodes(&mut cursor, 0)?;
-    assert_eq!(expected.inodes, inodes);
-
-    // チェックサムによるチェックなし版から復元して元のエントリと同一かを確認
-    cursor.set_position(0);
-    let actual = read_entry_without_check(&mut cursor, 0, 0)?;
-    assert_eq!(expected, actual);
-
-    // チェックサムによるチェックあり版から復元して元のエントリと同一かを確認
-    cursor.set_position(0);
-    let actual = read_entry(&mut cursor, 0)?;
-    assert_eq!(expected, actual);
-  }
-  Ok(())
-}
-
-/// 直列化したバイナリの任意の位置のバイトを破損させて、破損位置のフィールドに対して想定するエラーが発生することを
-/// 検証します。
-#[test]
-fn garbled_at_any_position() -> Result<()> {
-  for entry in sample_entries() {
-    // 正しく書き込まれたバイナリを取得
-    let mut buffer = Vec::new();
-    let write_length = write_entry(&mut buffer, &entry)?;
-    assert_eq!(write_length, buffer.len());
-
-    let mut cursor = io::Cursor::new(buffer.clone());
-    assert_eq!(entry, read_entry(&mut cursor, 0)?);
-
-    for position in 0u64..buffer.len() as u64 {
-      // データ破損の設定
-      cursor.seek(SeekFrom::Start(position))?;
-      let correct = cursor.read_u8()?;
-      cursor.seek(SeekFrom::Current(-1))?;
-      cursor.write_u8(!correct)?;
-
-      // データ破損に対して LSHT::read_entry() でエラーが発生することを検証
-      // TODO 最終的に、どのフィールドのバイト値が破損したかを識別して想定したエラーが検知されていることを確認する
-      cursor.seek(SeekFrom::Start(0))?;
-      let result = read_entry(&mut cursor, 0);
-      assert!(result.is_err(), "{result:?}");
-
-      // 破損したデータをもとに戻す
-      cursor.seek(SeekFrom::Start(position))?;
-      cursor.write_u8(correct)?;
-    }
-  }
-  Ok(())
-}
-
 #[test]
 fn test_bootstrap() {
   // 未初期化の空のストレージを指定してファイル識別子が書き込まれることを確認
@@ -118,12 +46,12 @@ fn test_bootstrap() {
   let storage = MemStorage::with(buffer.clone());
   let db = Slate::new(storage).unwrap();
   let content = buffer.read().unwrap();
-  let mut session = db.query().unwrap();
+  let mut query = db.snapshot().query().unwrap();
   assert_eq!(None, db.root());
   assert_eq!(0, db.n());
   assert_eq!(None, db.root_hash());
-  assert_eq!(0, session.n());
-  assert_eq!(None, session.get(1).unwrap());
+  assert_eq!(0, query.revision());
+  assert_eq!(None, query.get(1).unwrap());
   assert_eq!(4, content.len());
   assert_eq!(&STORAGE_IDENTIFIER[..], &content[..3]);
   assert_eq!(STORAGE_VERSION, content[3]);
@@ -132,13 +60,13 @@ fn test_bootstrap() {
   let n = 100;
   let samples = (0..=n as u64)
     .map(|i| (0u64..i).map(|j| splitmix64(i * i + j)).collect::<Vec<_>>())
-    .map(|values| values.iter().map(|i| i.to_le_bytes().to_vec()).collect::<Vec<_>>())
+    .map(|value| value.iter().map(|i| i.to_le_bytes().to_vec()).collect::<Vec<_>>())
     .map(|values| {
       // 疑似ランダムな列の直列化形式を取得
       let buffer = Arc::new(RwLock::new(Vec::new()));
       let storage = MemStorage::with(buffer.clone());
       let mut db = Slate::new(storage).unwrap();
-      for value in &values {
+      for value in values.iter() {
         db.append(value).unwrap();
       }
       let buffer = buffer.clone().read().unwrap().clone();
@@ -150,8 +78,9 @@ fn test_bootstrap() {
   for (values, buffer) in samples {
     let storage = MemStorage::with(Arc::new(RwLock::new(buffer)));
     let db = Slate::new(storage).unwrap();
-    let mut query = db.query().unwrap();
+    let mut query = db.snapshot().query().unwrap();
     for (i, expected) in values.iter().enumerate() {
+      println!("{}/{}: {expected:?}", i + 1, db.n());
       let actual = query.get(i as u64 + 1).unwrap().unwrap();
       assert_eq!(expected, actual.as_ref());
     }
@@ -173,7 +102,7 @@ fn test_append_and_get() {
   const N: u64 = 100;
   for n in 1..=N {
     let db = prepare_db(n, PAYLOAD_SIZE);
-    let mut query = db.query().unwrap();
+    let mut query = db.snapshot().query().unwrap();
 
     // 単一の葉ノードを参照
     for i in 0..n {
@@ -186,54 +115,6 @@ fn test_append_and_get() {
     // 範囲外のノードを参照
     assert!(query.get(0).unwrap().is_none());
     assert!(query.get(n + 1).unwrap().is_none());
-  }
-}
-
-/// ハッシュ付き値参照で取得した値とハッシュ値の検証。
-#[test]
-fn test_get_values_with_hashes() {
-  const N: u64 = 100;
-  for n in 1..=N {
-    let db = prepare_db(n, PAYLOAD_SIZE);
-    let mut query = db.query().unwrap();
-    let tree = NthGenHashTree::new(n);
-    for i in 0..n {
-      for j in 0..=ceil_log2(i + 1) {
-        // 範囲外のノードを参照
-        assert!(query.get_values_with_hashes(0, j).unwrap().is_none());
-        assert!(query.get_values_with_hashes(n + 1, j).unwrap().is_none());
-
-        if j != 0 && tree.inode(i + 1, j).is_none() {
-          continue;
-        }
-
-        // 中間ノードを指定してそのノードに属する値をハッシュ値付きですべて参照
-        let data_set = query.get_values_with_hashes(i + 1, j).unwrap().unwrap();
-
-        // ルートハッシュを検証
-        assert_eq!(db.root_hash().unwrap(), data_set.root().hash);
-
-        // 想定した範囲の値を取得しているか
-        let range = range(i + 1, j);
-        let min = range.clone().min().unwrap();
-        let max = range.clone().max().unwrap();
-        assert_eq!((max - min) as usize + 1, data_set.values.len());
-
-        // 取得した値はすべて想定した値か
-        for (x, k) in range.enumerate() {
-          let expected = random_payload(PAYLOAD_SIZE, data_set.values[x].i);
-          assert_eq!(k, data_set.values[x].i);
-          assert_eq!(expected, data_set.values[x].value);
-        }
-
-        // ルートノードからの経路は想定と一致するか
-        assert_eq!(tree.path_to(i + 1, j).unwrap().steps.len(), data_set.branches.len());
-        for (expected, actual) in tree.path_to(i + 1, j).unwrap().steps.iter().zip(data_set.branches.iter()) {
-          assert_eq!(expected.neighbor.i, actual.i);
-          assert_eq!(expected.neighbor.j, actual.j);
-        }
-      }
-    }
   }
 }
 
@@ -254,64 +135,65 @@ fn prepare_db(n: u64, payload_size: usize) -> Slate<MemStorage> {
   db
 }
 
-/// エントリの直列表現のチェックサムを検証します。
-fn verify_checksum(entry: &[u8]) {
-  let mut cursor = io::Cursor::new(entry);
+/// 指定されたストレージが仕様に準拠していることを検証します。
+pub fn verify_storage_spec<S: Storage>(storage: &mut S) {
+  // まだ書き込んでいない状態では末尾のエントリは存在しない
+  let (entry, first_position) = storage.boot().unwrap();
+  assert!(entry.is_none());
 
-  // エントリの直列化表現に記録されているチェックサムを参照
-  cursor.seek(SeekFrom::End(-8)).unwrap();
-  let expected = cursor.read_u64::<LittleEndian>().unwrap();
+  // 書き込みと読み込みを相互に実行
+  let mut positions = [first_position].to_vec();
+  for i in 0..1024 {
+    // let value = splitmix64(i as u64);
+    if positions.len() == 1 || splitmix64(i as u64) < u64::MAX / 2 {
+      // 書き込みの実行
+      let i = positions.len() as u64;
+      let position = *positions.last().unwrap();
+      let value = i.to_le_bytes().to_vec();
+      let entry = build_entry(i, &value, &positions);
+      positions.push(storage.put(position, &entry).unwrap());
+    } else {
+      // 読み込みの実行
+      let rand = splitmix64(!i as u64);
+      let i = (rand % (positions.len() as u64 - 1) + 1) as Index;
+      let position = positions[i as usize - 1];
+      let value = i.to_le_bytes().to_vec();
+      let expected = build_entry(i, &value, &positions);
 
-  // エントリの実際のチェックサムを算出
-  let actual = checksum(&entry[0..entry.len() - 8]);
-
-  assert_eq!(expected, actual);
+      let mut cursor = storage.cursor().unwrap();
+      let entry = cursor.get(position, i).unwrap();
+      assert_eq!(i, entry.enode.meta.address.i);
+      assert_eq!(0, entry.enode.meta.address.j);
+      assert_eq!(position, entry.enode.meta.address.position);
+      assert_eq!(&value, entry.enode.payload.as_ref());
+      let hash = Hash::from_bytes(&value);
+      assert_eq!(hash, entry.enode.meta.hash);
+      assert_eq!(&expected, &entry);
+    }
+  }
 }
 
-/// 指定されたバイナリデータに対するチェックサムを算出。
-fn checksum(bytes: &[u8]) -> u64 {
-  let builder = HighwayBuildHasher::new(Key(CHECKSUM_HW64_KEY));
-  let mut hasher = builder.build_hasher();
-  hasher.write_all(bytes).unwrap();
-  hasher.finish()
-}
-
-// TODO ストレージ末尾の 4 バイトの指す位置がたまたま最後より前の要素だった場合に、その要素を最後の要素とみなして
-// 後続が上書きされないように検証すること。
-
-/// 単体のエントリの書き込みと読み込みに使用する代表的なエントリを参照。
-fn sample_entries() -> Vec<Entry> {
-  vec![
-    create_sample_entry(1, Vec::new()),
-    create_sample_entry(1, random_payload(5, 302875)),
-    create_sample_entry(2, random_payload(826, 48727)),
-    create_sample_entry(3, random_payload(826, 48727)),
-  ]
-}
-
-fn create_sample_entry(i: Index, payload: Vec<u8>) -> Entry {
-  let position = 0;
+fn build_entry(i: Index, value: &[u8], positions: &[Index]) -> Entry {
+  let position = positions[i as usize - 1];
   let model = NthGenHashTree::new(i);
   let enode = ENode {
-    meta: MetaInfo { address: Address { i, j: 0, position }, hash: random_hash(position ^ i) },
-    payload: Arc::new(payload),
+    meta: MetaInfo::new(Address::new(i, 0, position), Hash::from_bytes(value)),
+    payload: Arc::new(value.to_vec()),
   };
   let inodes = model
     .inodes()
     .iter()
-    .map(|inode| INode {
-      meta: MetaInfo {
-        address: Address { i: inode.node.i, j: inode.node.j, position },
-        hash: random_hash(position ^ inode.node.j as u64),
-      },
-      left: Address { i: inode.left.i, j: inode.left.j, position },
-      right: Address { i: inode.right.i, j: inode.right.j, position },
+    .map(|inode| {
+      let meta = MetaInfo::new(Address::new(inode.node.i, inode.node.j, position), Hash::new([0; Hash::SIZE]));
+      let left = Address::new(inode.left.i, inode.left.j, positions[inode.left.i as usize - 1]);
+      let right = Address::new(inode.right.i, inode.right.j, positions[inode.right.i as usize - 1]);
+      INode::new(meta, left, right)
     })
     .collect();
-  Entry { enode, inodes }
+  Entry::new(enode, inodes)
 }
 
-fn random_payload(length: usize, s: u64) -> Vec<u8> {
+pub fn random_payload(length: usize, s: u64) -> Vec<u8> {
   let mut seed = [0u32; 2];
   seed[0] = (s & 0xFFFFFFFF) as u32;
   seed[1] = ((s >> 8) & 0xFFFFFFFF) as u32;
@@ -319,71 +201,6 @@ fn random_payload(length: usize, s: u64) -> Vec<u8> {
   let mut bytes = vec![0u8; length];
   rand.fill_bytes(&mut bytes);
   bytes
-}
-
-fn random_hash(s: u64) -> Hash {
-  let mut seed = [0u32; 2];
-  seed[0] = (s & 0xFFFFFFFF) as u32;
-  seed[1] = ((s >> 8) & 0xFFFFFFFF) as u32;
-  let mut rand = MT19937::new_with_slice_seed(&seed);
-  let mut hash = [0u8; HASH_SIZE];
-  rand.fill_bytes(&mut hash);
-  Hash::new(hash)
-}
-
-/// ファイルストレージの適合テスト。
-#[test]
-fn test_file_storage() {
-  let file = temp_file("slate-storage", ".db");
-  let mut db = FileStorage::new(&file).unwrap();
-  verify_storage_spec(&mut db).unwrap_or_else(|_| panic!("Slate compliance test filed: {}", file.to_string_lossy()));
-  remove_file(&file).unwrap_or_else(|_| panic!("failed to remove temporary file: {}", file.to_string_lossy()));
-}
-
-/// メモリーストレージの適合テスト
-#[test]
-fn test_memory_storage() {
-  verify_storage_spec(&mut MemStorage::new()).expect("Slate compliance test filed");
-}
-
-/// 指定されたストレージが仕様に準拠していることを検証します。
-pub fn verify_storage_spec(storage: &mut dyn Storage) -> Result<()> {
-  // まだ書き込んでいない状態での末尾は 0
-  let mut reader1 = storage.cursor().expect("failed to open cursor as read-only #1");
-  let zero_position = reader1.seek(SeekFrom::End(0)).expect("failed to seek on zero-length storage");
-  assert_eq!(0, zero_position);
-
-  // 書き込みの実行
-  let values = (0u8..=255).collect::<Vec<u8>>();
-  storage.write_all(&values).unwrap_or_else(|_| panic!("fail to write"));
-  storage.flush().unwrap();
-
-  // 既存のカーソルは書き込みの影響を受けない
-  assert_eq!(zero_position, reader1.stream_position()?);
-
-  // 書き込み後に 2 つめの読み込み専用カーソルをオープン
-  let mut reader2 = storage.cursor().expect("failed to open cursor as read-only #2");
-
-  // 読み込みの実行
-  for i in values.iter() {
-    let value = reader1.read_u8().unwrap_or_else(|e| panic!("failed to read at {}, {}", *i, e));
-    assert_eq!(*i, value);
-  }
-
-  // シークしてもう一度読み込みを実行 (ランダムアクセス)
-  reader1.seek(SeekFrom::Start(0)).expect("fail to seek from 256 to 0");
-  let mut rand = mt19937::MT19937::new_with_slice_seed(&[0u32]);
-  for _ in 0..100 {
-    let i = (rand.next_u32() & 0xFF) as u8;
-    reader1.seek(SeekFrom::Start(i as u64)).unwrap_or_else(|_| panic!("failed to seek to {i}"));
-    let value = reader1.read_u8().unwrap_or_else(|_| panic!("failed to read from cursor #1 at {i}"));
-    assert_eq!(i, value);
-    let i = (rand.next_u32() & 0xFF) as u8;
-    reader2.seek(SeekFrom::Start(i as u64)).unwrap_or_else(|_| panic!("failed to seek to {i}"));
-    let value = reader2.read_u8().unwrap_or_else(|_| panic!("failed to read from cursor #2 at {i}"));
-    assert_eq!(i, value);
-  }
-  Ok(())
 }
 
 /// 指定された接頭辞と接尾辞を持つ 0 バイトのテンポラリファイルをシステムのテンポラリディレクトリ上に作成します。


### PR DESCRIPTION
This PR enables the application of block device-like storage to KVS. Storage must support put() and get() via a cursor.